### PR TITLE
Add commented #includes to loadouts.sqf

### DIFF
--- a/customization/loadouts.sqf
+++ b/customization/loadouts.sqf
@@ -1,0 +1,5 @@
+//#include "loadouts\RURiflePlatoon.sqf"
+//#include "loadouts\BAF.sqf"
+//#include "loadouts\1989USARMY.sqf"
+//#include "loadouts\1989VDV.sqf"
+//#include "loadouts\2000MSV.sqf"


### PR DESCRIPTION
Adds Cake's request changes to loadouts.sqf so people who don't know how to write #include can make missions

**When merged this pull request will:**
- Adds commented out includes for default gearscripts
