### PR TITLE
Fix for Anti ND module

### DIFF
--- a/modules/anti_nd/functions/anti_nd/fn_Init.sqf
+++ b/modules/anti_nd/functions/anti_nd/fn_Init.sqf
@@ -1,4 +1,5 @@
 #include "script_component.hpp"
+#include "..\..\settings.sqf"
 
 [{(!isNull ace_player)}, {
     private _FiredEh = player addEventHandler ["FiredMan", {
@@ -20,13 +21,14 @@
     }];
     SETPLVAR(EHid,_FiredEh);
     SETPLVAR(Active,true);
-    
+
     [{
         ((GETMVAR(Time,30)) isEqualTo 0 || {CBA_missionTime >= GETMVAR(Time,30)})
-        && {((EGETMVAR(FW,SpawnPos,getpos player)) distance player) <= GETMVAR(Distance,200)}
+        && {(GETMVAR(Distance,200) isEqualTo 0) || {((EGETMVAR(FW,SpawnPos,getpos player)) distance player) >= GETMVAR(Distance,200)}}
     },{
-        player removeEventHandler ["FiredMan", _this];
+        private _eh = (_this select 0);
+        player removeEventHandler ["FiredMan", _eh];
         SETPLVAR(EHid,"DISABLED");
         SETPLVAR(Active,false);
-    }, _FiredEh] call CBA_fnc_waitUntilAndExecute;
+    }, [_FiredEh]] call CBA_fnc_waitUntilAndExecute;
 }] call CBA_fnc_waitUntilAndExecute;

--- a/modules/anti_nd/preinitClient.sqf
+++ b/modules/anti_nd/preinitClient.sqf
@@ -1,8 +1,7 @@
 #include "script_component.hpp"
 
-private _version = 0.1;
+private _version = 0.2;
 
-["Anti ND", "Prevents negligent discharges at spawn.", "Starfox64 & PIZZADOX", _version] call EFUNC(FW,RegisterModule);
+["Anti ND", "Prevents negligent discharges at spawn.", "Starfox64 &amp; PIZZADOX", _version] call EFUNC(FW,RegisterModule);
 
 [] call FUNC(Init);
-


### PR DESCRIPTION
**When merged this pull request will:**
- Fix the anti nd module.

There were 3 issues:
- The settings file wasn't being included so none of the settings variables were setup and therefore effectively ignored
- The logic to remove the fired event handler was not checking a case where a time setting was active but the distance setting disabled
- The logic to remove the fired event handler had the distance logic round the wrong way (checking for if the player was within the distance set, not outside of it, to remove the event handler)

![Test evidence](https://user-images.githubusercontent.com/8123733/113915326-8e3ba080-97d6-11eb-8e03-04e254e2ce02.png)

