### PR TITLE
Fixed admin tab

### DIFF
--- a/customization/briefing.sqf
+++ b/customization/briefing.sqf
@@ -162,7 +162,7 @@ ENDTAB;
 
 if (!isNil "uo_fnc_hasGMAccess" && {call uo_fnc_hasGMAccess}) then {
 	NEWTAB("ADMIN NOTES")
-	<font size='10' FNTETK>
+	<font size='10' face='RobotoCondensedBold'>
 		<br/>THIS IS ONLY VISIBLE TO LOGGED-IN ADMINS AND GMS
 	</font>
 	ENDTAB;


### PR DESCRIPTION
Admin briefing tab was looking for a font, yet the command 'Face=' was not entered, so as a result, any text input in the tab never showed up.
Now fixed.

