### PR TITLE
Tracking markers module

### DIFF
--- a/modules/modules.sqf
+++ b/modules/modules.sqf
@@ -44,6 +44,7 @@ Additional modules that can be enabled by removing the //
 //#include "start_on_team_color\root.sqf"
 //#include "start_text\root.sqf"
 //#include "task_control\root.sqf"
+//#include "tracking_markers\root.sqf"
 //#include "start_in_vehicle\root.sqf"
 //#include "headless_ai\root.sqf"
 //#include "weapon_helper\root.sqf"

--- a/modules/tracking_markers/functions/CfgFunctions.hpp
+++ b/modules/tracking_markers/functions/CfgFunctions.hpp
@@ -1,0 +1,8 @@
+class COMPONENT {
+	tag = COMPONENT;
+	class TRKMRKS {
+		file = "modules\tracking_markers\functions\TRKMRKS";
+		class trackMarker {};
+		class untrackMarker {};
+	};
+};

--- a/modules/tracking_markers/functions/TRKMRKS/fn_trackMarker.sqf
+++ b/modules/tracking_markers/functions/TRKMRKS/fn_trackMarker.sqf
@@ -1,0 +1,8 @@
+#include "script_component.hpp"
+
+params[
+  ["_markerName", "trackingMarker", ["trackingMarker"]],
+  ["_objectToTrack", objNull, [objNull, player]]
+];
+
+GVAR(trackedMarkers) pushBack [_markerName, _objectToTrack];

--- a/modules/tracking_markers/functions/TRKMRKS/fn_trackMarker.sqf
+++ b/modules/tracking_markers/functions/TRKMRKS/fn_trackMarker.sqf
@@ -1,8 +1,8 @@
 #include "script_component.hpp"
 
 params[
-  ["_markerName", "trackingMarker", ["trackingMarker"]],
-  ["_objectToTrack", objNull, [objNull, player]]
+  ["_markerName", "trackingMarker", [""]],
+  ["_objectToTrack", objNull, [objNull]]
 ];
 
-GVAR(trackedMarkers) pushBack [_markerName, _objectToTrack];
+GVAR(trackedMarkers) pushBackUnique [_markerName, _objectToTrack];

--- a/modules/tracking_markers/functions/TRKMRKS/fn_untrackMarker.sqf
+++ b/modules/tracking_markers/functions/TRKMRKS/fn_untrackMarker.sqf
@@ -1,0 +1,18 @@
+#include "script_component.hpp"
+
+params[
+  ["_markerName", "trackingMarker", ["trackingMarker"]]
+];
+
+private _deleteIndex = -1;
+
+{
+    _x params ["_xMarkerName"];
+
+    if (_xMarkerName == _markerName) then {
+      _deleteIndex = _forEachIndex;
+      GVAR(trackedMarkers) deleteAt _deleteIndex;
+    }
+} forEach GVAR(trackedMarkers);
+
+_deleteIndex

--- a/modules/tracking_markers/functions/TRKMRKS/fn_untrackMarker.sqf
+++ b/modules/tracking_markers/functions/TRKMRKS/fn_untrackMarker.sqf
@@ -1,18 +1,9 @@
 #include "script_component.hpp"
 
 params[
-  ["_markerName", "trackingMarker", ["trackingMarker"]]
+  ["_markerName", "trackingMarker", [""]]
 ];
 
-private _deleteIndex = -1;
-
-{
-    _x params ["_xMarkerName"];
-
-    if (_xMarkerName == _markerName) then {
-      _deleteIndex = _forEachIndex;
-      GVAR(trackedMarkers) deleteAt _deleteIndex;
-    }
-} forEach GVAR(trackedMarkers);
-
+private _deleteIndex = GVAR(trackedMarkers) findif {_x select 0 == _markerName};
+GVAR(trackedMarkers) deleteAt _deleteIndex;
 _deleteIndex

--- a/modules/tracking_markers/functions/TRKMRKS/script_component.hpp
+++ b/modules/tracking_markers/functions/TRKMRKS/script_component.hpp
@@ -1,0 +1,2 @@
+#define COMPONENT TRKMRKS
+#include "..\..\script_component.hpp"

--- a/modules/tracking_markers/postInitServer.sqf
+++ b/modules/tracking_markers/postInitServer.sqf
@@ -5,13 +5,10 @@
 [{
   GVAR(trackedMarkers) apply {
     _x params [
-      ["_markerName", "trackingMarker", ["trackingMarker"]],
-      ["_objectToTrack", objNull, [objNull, player]]
+      ["_markerName", "trackingMarker", [""]],
+      ["_objectToTrack", objNull, [objNull]]
     ];
 
-    private _objPos = getPos _objectToTrack;
-
-    [_markerName, _objPos] remoteExec ["setMarkerPosLocal", 0, true];
-    _markerName setMarkerAlpha 1;
+    _markerName setMarkerPos _objectToTrack;
   };
 }, GVAR(markerUpdateInterval), []] call CBA_fnc_addPerFrameHandler;

--- a/modules/tracking_markers/postInitServer.sqf
+++ b/modules/tracking_markers/postInitServer.sqf
@@ -1,0 +1,17 @@
+#include "script_component.hpp"
+
+#include "settings.sqf"
+
+[{
+  GVAR(trackedMarkers) apply {
+    _x params [
+      ["_markerName", "trackingMarker", ["trackingMarker"]],
+      ["_objectToTrack", objNull, [objNull, player]]
+    ];
+
+    private _objPos = getPos _objectToTrack;
+
+    [_markerName, _objPos] remoteExec ["setMarkerPosLocal", 0, true];
+    _markerName setMarkerAlpha 1;
+  };
+}, GVAR(markerUpdateInterval), []] call CBA_fnc_addPerFrameHandler;

--- a/modules/tracking_markers/preInitClient.sqf
+++ b/modules/tracking_markers/preInitClient.sqf
@@ -1,0 +1,5 @@
+#include "script_component.hpp"
+
+private _version = 0.1;
+
+["Tracking Markers", "Markers which track objects and units, updating on the map.", "StatusRed", _version] call EFUNC(FW,RegisterModule);

--- a/modules/tracking_markers/root.sqf
+++ b/modules/tracking_markers/root.sqf
@@ -1,0 +1,19 @@
+#include "script_component.hpp"
+
+#ifdef description_XEH_PreInit
+	class COMPONENT {
+		clientInit = "'' call compile preprocessFileLineNumbers 'modules\tracking_markers\preInitClient.sqf'";
+	};
+#endif
+
+#ifdef description_XEH_PostInit
+	class COMPONENT {
+		serverInit = "'' call compile preprocessFileLineNumbers 'modules\tracking_markers\postInitServer.sqf'";
+	};
+#endif
+
+#ifdef description_external_functions
+	#include "functions\CfgFunctions.hpp"
+#endif
+
+#undef COMPONENT

--- a/modules/tracking_markers/script_component.hpp
+++ b/modules/tracking_markers/script_component.hpp
@@ -1,0 +1,2 @@
+#define COMPONENT TRKMRKS
+#include "..\..\core\script_macros.hpp"

--- a/modules/tracking_markers/settings.sqf
+++ b/modules/tracking_markers/settings.sqf
@@ -1,0 +1,36 @@
+// Tracking Markers - Markers which track objects and units, updating on the map.
+// Author: StatusRed
+
+// Functions
+/*
+ * FUNC(trackMarker)
+ *
+ * Make a marker track an object / player / unit.
+ *
+ * Arguments:
+ * 0: markerName <markerName>
+ * 1: object <object>
+ *
+ * Return Value:
+ * nothing
+ *
+ */
+
+ /*
+  * FUNC(untrackMarker)
+  *
+  * Make a marker tracking stop.
+  *
+  * Arguments:
+  * 0: markerName <markerName>
+  *
+  * Return Value:
+  * Index of the marker removed, -1 if it wasn't found.
+  *
+  */
+
+GVAR(trackedMarkers) = [[]]; // Leave this
+GVAR(markerUpdateInterval) = 30; // Number of seconds between marker updates on the map
+
+// Markers to track
+/* ["trackingMarker", test_unit] call FUNC(trackMarker); */


### PR DESCRIPTION
**When merged this pull request will:**
- Adds a new "Tracking Markers" module which allows mission makers to setup markers to track specific objects or units and specify how often this updates on the map. Useful for HVT missions or a moving objective etc.
