### PR TITLE
exclude hidden buildings from buildingSearch

### DIFF
--- a/modules/headless_ai/cfgFunctions/Get/fn_getBuildings.sqf
+++ b/modules/headless_ai/cfgFunctions/Get/fn_getBuildings.sqf
@@ -2,7 +2,7 @@
 
 
 params ["_pos",["_radius",100,[0]],["_blds",[],[[]]]];
-private _getblds = (_pos nearObjects ["building",_radius]) select {count(_x buildingPos -1) > 0};
+private _getblds = (_pos nearObjects ["building",_radius]) select {count (_x buildingPos -1) > 0 && {!(isObjectHidden _x)}};
 if (count _getblds < 1) exitWith {[objNull]};
 private _xbld = _getblds apply {[_x distance _pos, _x]};
 _xbld sort true;


### PR DESCRIPTION
adds in an additional check for hidden buildings
