### PR TITLE
Fix: Babel languages in spectator

### DIFF
--- a/modules/acre_setup/functions/ACRESetup/fn_ACRES_ClientInit.sqf
+++ b/modules/acre_setup/functions/ACRESetup/fn_ACRES_ClientInit.sqf
@@ -61,23 +61,21 @@ if(!isDedicated && hasInterface) then {
 		};
 
 		if (GVAR(ACRE_Enable_Babel)) then {
-			{_x call acre_api_fnc_babelAddLanguageType;} foreach GVAR(ACRE_All_Languages);
+			GVAR(ACRE_All_Languages) apply {_x call acre_api_fnc_babelAddLanguageType;};
 
 			(GVAR(ACRE_Languages_Babel) select _side_i) call acre_api_fnc_babelSetSpokenLanguages;
 
 			private _languages = player getVariable ["ACRE_Languages", []];
 
 			if (count _languages > 0) then {
-
 				_languages call acre_api_fnc_babelSetSpokenLanguages;
-
 			};
 		};
 
 		[{[] call acre_api_fnc_isInitialized}, {
 			private _channels = player getVariable ["ACRE_Channels", []];
 
-			{
+			_channels apply {
 				_x params [
 					["_radio", ""],
 					["_channel", 1],
@@ -88,7 +86,7 @@ if(!isDedicated && hasInterface) then {
 					[_radioID, _channel] call acre_api_fnc_setRadioChannel;
 					[_radioID, _spatial] call acre_api_fnc_setRadioSpatial;
 				};
-			} foreach _channels;
+			};
 		}, []] call CBA_fnc_waitUntilAndExecute;
 	}, []] call CBA_fnc_waitUntilAndExecute;
 };

--- a/modules/acre_setup/postInitClient.sqf
+++ b/modules/acre_setup/postInitClient.sqf
@@ -1,3 +1,7 @@
 #include "..\..\core\script_macros.hpp"
 
+params ["_unit"];
+
+if (GETVAR(_unit,Spectating,false)) exitWith { }; // If the unit is spectating, don't run this, it will overwrite their access to all languages
+LOG_1("Running ACRE setup for %1", _unit);
 [] call FUNC(ACRES_ClientInit);

--- a/modules/acre_setup/preInitClient.sqf
+++ b/modules/acre_setup/preInitClient.sqf
@@ -1,5 +1,5 @@
 #include "..\..\core\script_macros.hpp"
 
-private _version = 0.1;
+private _version = 0.2;
 
 ["ACRE setup", "Module for all ACRE settings.", "BlackHawk &amp; StatusRed", _version] call FUNC(RegisterModule);

--- a/modules/acre_setup/root.sqf
+++ b/modules/acre_setup/root.sqf
@@ -12,7 +12,7 @@
 
 #ifdef description_XEH_InitPost_CAManBase
 	class ACRES {
-		clientInit = "'' call compile preprocessFileLineNumbers 'modules\acre_setup\postInitClient.sqf'";
+		clientInit = "_this call compile preprocessFileLineNumbers 'modules\acre_setup\postInitClient.sqf'";
 	};
 #endif
 


### PR DESCRIPTION
**When merged this pull request will:**
- Fix the issue of (when babel is enabled) players not being able to hear team mates set to a different language while spectating. I believe this was happening due to the ACRE client init running again overwriting the spectator script assigning them all the babel languages.
- Bug reported here: https://github.com/Global-Conflicts-ArmA/Olsen-Framework-Arma-3/issues/130
