### PR TITLE
Fix: FIREMISSION - Allow markers to be targetted

### DIFF
--- a/modules/firemission/functions/FIREMIS/fn_FIREMIS_GetPointFiremissionText.sqf
+++ b/modules/firemission/functions/FIREMIS/fn_FIREMIS_GetPointFiremissionText.sqf
@@ -11,17 +11,16 @@ params[
   ["_roundType", 0, [0]]
 ];
 
-private	_rounds = ((_unit call FUNC(FIREMIS_Dia_GetArtyAmmo)) select _roundType);
+private	_rounds = (_unit call FUNC(FIREMIS_Dia_GetArtyAmmo)) select _roundType;
 
 private _text =  getText (configfile / "CfgMagazines" / (_rounds select 0) / "displayName");
 
 private	_unitName = _unit call FUNC(FIREMIS_Dia_GetArtyDisplayName);
 
-private _gridPos = "";
-if ((_target isEqualType "") && !((markerShape _target) isEqualTo "")) then {
-  _gridPos = (mapGridPosition (getMarkerPos _target));
+private _gridPos = if (_target isEqualType "" && {markerShape _target isNotEqualTo ""}) then {
+  mapGridPosition (getMarkerPos _target)
 } else {
-  _gridPos = (mapGridPosition _target);
+  mapGridPosition _target
 };
 
 private _ret = 	"Name: " + _unitName + "\n" +

--- a/modules/firemission/functions/FIREMIS/fn_FIREMIS_GetPointFiremissionText.sqf
+++ b/modules/firemission/functions/FIREMIS/fn_FIREMIS_GetPointFiremissionText.sqf
@@ -2,7 +2,7 @@
 
 params[
   ["_unit", objNull, [objNull]],
-  ["_target", objNull, [objNull, []]],
+  ["_target", objNull, ["", objNull, []]],
   ["_dispersion", 100, [100]],
   ["_burstCount", 0, [0]],
   ["_burstSize", 0, [0]],
@@ -17,10 +17,17 @@ private _text =  getText (configfile / "CfgMagazines" / (_rounds select 0) / "di
 
 private	_unitName = _unit call FUNC(FIREMIS_Dia_GetArtyDisplayName);
 
+private _gridPos = "";
+if ((_target isEqualType "") && !((markerShape _target) isEqualTo "")) then {
+  _gridPos = (mapGridPosition (getMarkerPos _target));
+} else {
+  _gridPos = (mapGridPosition _target);
+};
+
 private _ret = 	"Name: " + _unitName + "\n" +
     "Firemission type: Point-Firemission \n" +
     "Shell: " + _text +" \n" +
-    "Grid: " + (mapGridPosition _target) + "\n" +
+    "Grid: " + _gridPos + "\n" +
     "Dispersion: " + (str _dispersion) +"\n" +
     "Number of Bursts: " + (str _burstCount) +"\n" +
     "Rounds per Burst: " + (str _burstSize) +"\n" +

--- a/modules/firemission/functions/FIREMIS/fn_FIREMIS_InternalSpottingFiremission.sqf
+++ b/modules/firemission/functions/FIREMIS/fn_FIREMIS_InternalSpottingFiremission.sqf
@@ -2,7 +2,7 @@
 
 params[
   ["_unit", objNull, [objNull]],
-  ["_target", objNull, [objNull, []]],
+  ["_target", objNull, ["", objNull, []]],
   ["_roundClassName", "", [""]]
 ];
 
@@ -17,7 +17,13 @@ params[
   while{(_dis >_minSpottedDistance && SPOTTINGROUNDSREQUIRED)} do
   {
       private _randomPos = [[[_target, GVAR(tempAcc)]],[]] call BIS_fnc_randomPos;
-      _dis = _randomPos distance2D _target;
+
+      private _targetPos = _target;
+      if ((_target isEqualType "") && !((markerShape _target) isEqualTo "")) then {
+        _targetPos = (getMarkerPos _target);
+      };
+
+      _dis = _randomPos distance2D _targetPos;
       private _eta = [_unit,_randomPos, _roundClassName] call FUNC(FIREMIS_Dia_GetArtyEta);
       _unit commandArtilleryFire [_randomPos, _roundClassName, 1];
 

--- a/modules/firemission/preInitClient.sqf
+++ b/modules/firemission/preInitClient.sqf
@@ -1,5 +1,5 @@
 #include "..\..\core\script_macros.hpp"
 
-private _version = 0.3;
+private _version = 0.4;
 
 ["Firemission", "Custom Artillery Strike Missions", "Sacher &amp; StatusRed", _version] call FUNC(RegisterModule);


### PR DESCRIPTION
**When merged this pull request will:**
- Fix an issue discovered when testing some custom random mortar firing with TheLocalPub. Basically, although several functions are supposed to support passing a marker name to them as a target, this wasn't supported by the code itself. I've fixed this and we've tested it with his mission.
