### PR TITLE
Attempt to fix double counting of players on a team

### DIFF
--- a/core/functions/spectator/fn_startSpectator.sqf
+++ b/core/functions/spectator/fn_startSpectator.sqf
@@ -3,6 +3,7 @@
 if (GETVAR(player,Spectating,false)) exitWith {};
 
 SETPVAR(player,Dead,true); //Tells the framework the player is dead
+SETPVAR(player,Spectating,true); //Tells the framework the player is spectating
 
 [(player), true] remoteExecCall ["hideObject", 0];
 [(player), true] remoteExecCall ["hideObjectGlobal", 2];

--- a/core/preinitServer.sqf
+++ b/core/preinitServer.sqf
@@ -103,7 +103,11 @@ GVAR(MissionEnded) = false; //Mission has not ended
     };
     LOG_1("eventCheckRespawnTickets_Response called: %1",_unit);
     [QGVAR(eventCheckRespawnTickets_Response), _canRespawn, _unit] call CBA_fnc_targetEvent;
-	[_unit] call FUNC(EventRespawned);
+
+  // Wait is necessary so that the client has a chance to update the Spectating variable
+  [{
+    [_unit] call FUNC(EventRespawned);
+  }, [_unit], 2] call CBA_fnc_waitAndExecute;
 }] call CBA_fnc_addEventHandler;
 
 [QGVAR(ShotCountEvent), {


### PR DESCRIPTION
**When merged this pull request will:**
- Attempting to fix an issue reported by Reddish, when a player dies but has no respawns left it seems to be adding to the count for that team, this then effects end conditions for casualty percentage on player teams not working.
