### PR TITLE
Fix/spectator cas count

### DIFF
--- a/core/functions/fn_eventRespawned.sqf
+++ b/core/functions/fn_eventRespawned.sqf
@@ -13,15 +13,13 @@
  */
 
 #include "script_component.hpp"
-
-params ["_new", "_corpse"];
-SETVAR(_new,Body,_corpse);
+params ["_unit", ["_spectator", false, [false]]];
 
 LOG("Server Event Respawned called");
-if (GETVAR(_new,Spectating,false)) then {
-    _new call FUNC(UntrackUnit);
+if (_spectator || GETVAR(_unit,Spectating,false)) then {
+    _unit call FUNC(UntrackUnit);
 } else {
-    SETPVAR(_new,Dead,false);
-    SETPVAR(_new,Spectating,false);
-    _new call FUNC(EventSpawned);
+    SETPVAR(_unit,Dead,false);
+    SETPVAR(_unit,Spectating,false);
+    _unit call FUNC(EventSpawned);
 };

--- a/core/functions/spectator/fn_cameraHandleKeyDown.sqf
+++ b/core/functions/spectator/fn_cameraHandleKeyDown.sqf
@@ -23,12 +23,10 @@ disableserialization;
 
 private _key = _this select 1;
 
-if (_key isEqualTo DIK_F1) exitWith {
-    true
-};
-
-if (_key isEqualTo DIK_SPACE) exitWith {
-    true
+if (isMultiplayer && {!([] call CBA_fnc_isDebugConsoleAllowed)}) then {
+    if (_key in [DIK_F1, DIK_SPACE]) exitWith {
+        true
+    };
 };
 
 if (_key in [DIK_APOSTROPHE, DIK_ESCAPE]) exitWith {

--- a/core/functions/spectator/fn_startSpectator.sqf
+++ b/core/functions/spectator/fn_startSpectator.sqf
@@ -1,8 +1,9 @@
 #include "script_component.hpp"
 
-if (GETVAR(player,Spectating,false)) exitWith {};
+if (GETPLVAR(Spectating,false)) exitWith {};
 
-SETPVAR(player,Dead,true); //Tells the framework the player is dead
+SETPLPVAR(Dead,true); //Tells the framework the player is dead
+SETPLPVAR(Spectating,true); //Player is now spectating
 
 [(player), true] remoteExecCall ["hideObject", 0];
 [(player), true] remoteExecCall ["hideObjectGlobal", 2];

--- a/core/functions/spectator/fn_startSpectator.sqf
+++ b/core/functions/spectator/fn_startSpectator.sqf
@@ -4,6 +4,7 @@ if (GETPLVAR(Spectating,false)) exitWith {};
 
 SETPLPVAR(Dead,true); //Tells the framework the player is dead
 SETPLPVAR(Spectating,true); //Player is now spectating
+SETMVAR(Spectating,true); //set local global var to spectating
 
 [(player), true] remoteExecCall ["hideObject", 0];
 [(player), true] remoteExecCall ["hideObjectGlobal", 2];

--- a/core/preinitClient.sqf
+++ b/core/preinitClient.sqf
@@ -177,7 +177,8 @@ FUNC(eg_keyHandler2) = {
     if (_response) then {
         [QGVAR(eventPlayerRespawned), [1]] call CBA_fnc_localEvent;
     } else {
-        [] call FUNC(StartSpectator);
+        [] call FUNC(StartSpectator); // spectator var is set in this function
+        [QGVAR(respawnEvent), [player, true]] call CBA_fnc_serverEvent;
     };
 }] call CBA_fnc_addEventHandler;
 

--- a/core/preinitServer.sqf
+++ b/core/preinitServer.sqf
@@ -25,9 +25,9 @@ GVAR(MissionEnded) = false; //Mission has not ended
 }] call CBA_fnc_addEventHandler;
 
 [QGVAR(respawnEvent), {
-    params [["_unit", objNull, [objNull]]];
-    LOG_1("respawnEvent started: %1",_unit);
-	[_unit] call FUNC(EventRespawned);
+    params [["_unit", objNull, [objNull]], ["_spectator", false, [false]]];
+    LOG_2("respawnEvent started: %1 spectator: %2",_unit,_spectator);
+	[_unit, _spectator] call FUNC(EventRespawned);
 }] call CBA_fnc_addEventHandler;
 
 [QGVAR(eventCheckRespawnTickets), {
@@ -103,7 +103,6 @@ GVAR(MissionEnded) = false; //Mission has not ended
     };
     LOG_1("eventCheckRespawnTickets_Response called: %1",_unit);
     [QGVAR(eventCheckRespawnTickets_Response), _canRespawn, _unit] call CBA_fnc_targetEvent;
-	[_unit] call FUNC(EventRespawned);
 }] call CBA_fnc_addEventHandler;
 
 [QGVAR(ShotCountEvent), {

--- a/core/xeh/fn_respawnCAManBase.sqf
+++ b/core/xeh/fn_respawnCAManBase.sqf
@@ -7,8 +7,8 @@ LOG("Respawned_Event called");
 //Makes the player go into spectator mode when dead or respawn if he has respawn tickets
 if (isPlayer _unit) then {
     LOG_1("respawn XEH handle for isPlayer started: %1",_unit);
+    SETVAR(_unit,Body,_body);
     [_unit, _body] call FUNC(SpectatePrep);
 } else {
     [QGVAR(RespawnedEvent), _unit] call CBA_fnc_serverEvent;
 };
-


### PR DESCRIPTION
- sets body value on respawnCAManBase
- adds a spectator param override on eventRespawned
- sends the respawnEvent to server after startSpectator has been called ( spectating var sent publically before serverEvent called)
- sets spectating var in startSpectator
- correct macros for dead and spectating in eventRespawned
- singleplayer and admin exception to camera keyholders
