### PR TITLE
Missing gearSetting for removeAllGear.

### DIFF
--- a/core/functions/fn_gearScript.sqf
+++ b/core/functions/fn_gearScript.sqf
@@ -19,8 +19,8 @@ if !(_groupId isEqualTo "") then {
 	(group _unit) setGroupId [_groupId];
 };
 
-if (GETMVAR(removeGear,true)) then {
-	[] call FUNC(removeAllGear);
+if (GETMVAR(removeAllGear, true)) then {
+	[_unit] call FUNC(removeAllGear);
 };
 
 SETPVAR(_unit,Loadout,_type);

--- a/customization/gearSettings.sqf
+++ b/customization/gearSettings.sqf
@@ -3,3 +3,6 @@ GVAR(force_remove_facewear) = false;
 
 //forces adding an item to inventory. Works only if container is specified!
 GVAR(enableOverfill) = true;
+
+//when set to false, existing gear will not be removed
+GVAR(removeAllGear) = true;


### PR DESCRIPTION
**When merged this pull request will:**
- Missing gear setting to remove all gear which should be enabled by default, also when it was trying to remove the gear it wasn't passing a unit to the function so even though it was calling it, it wasn't providing a unit to call it on.