### PR TITLE
Default patrol distance setting

### DIFF
--- a/modules/headless_ai/cfgFunctions/task/fn_taskAssign.sqf
+++ b/modules/headless_ai/cfgFunctions/task/fn_taskAssign.sqf
@@ -89,7 +89,8 @@ switch (_task) do {
         _taskSet call FUNC(taskDropOff);
     };
     default {
-        _taskSet call FUNC(taskPatrol);
+        _radius = GETMVAR(PatrolDistance, 200);
+        [_group,_pos,_radius,_wait,_behaviour,_combat,_speed,_formation] call FUNC(taskPatrol);
     };
 };
 true


### PR DESCRIPTION
Makes the PatrolDistance setting affect the default patrolling radius of groups with no task (default to Patrol)
