### PR TITLE
Bugfix/individual team tickets

### DIFF
--- a/core/functions/fn_spectatePrep.sqf
+++ b/core/functions/fn_spectatePrep.sqf
@@ -28,6 +28,29 @@ if (GVAR(RespawnTickets) > 0) then {
     [QGVAR(eventPlayerRespawned), [0]] call CBA_fnc_localEvent;
     [QGVAR(respawnEvent), [_unit]] call CBA_fnc_serverEvent;
 } else {
-    LOG_1("eventCheckRespawnTickets called: %1",_unit);
-    [QGVAR(eventCheckRespawnTickets), _unit] call CBA_fnc_serverEvent;
+    private _indTicketVar = switch (side _unit) do {
+        case west: {
+            GVAR(IndividualRespawnTickets_West)
+        };
+        case east: {
+            GVAR(IndividualRespawnTickets_East)
+        };
+        case independent: {
+            GVAR(IndividualRespawnTickets_Ind)
+        };
+        case civilian: {
+            GVAR(IndividualRespawnTickets_Civ)
+        };
+        default {
+            -1
+        };
+    };
+    if (_indTicketVar isEqualTo -1 || _indTicketVar > 0) then {
+        _indTicketVar = _indTicketVar - 1;
+        LOG_1("eventCheckRespawnTickets called: %1",_unit);
+        [QGVAR(eventCheckRespawnTickets), _unit] call CBA_fnc_serverEvent;
+    } else {
+        [] call FUNC(StartSpectator); // spectator var is set in this function
+        [QGVAR(respawnEvent), [player, true]] call CBA_fnc_serverEvent;
+    };
 };

--- a/core/functions/fn_spectatePrep.sqf
+++ b/core/functions/fn_spectatePrep.sqf
@@ -30,23 +30,22 @@ if (GVAR(RespawnTickets) > 0) then {
 } else {
     private _indTicketVar = switch (side _unit) do {
         case west: {
-            GVAR(IndividualRespawnTickets_West)
+            QGVAR(IndividualRespawnTickets_West)
         };
         case east: {
-            GVAR(IndividualRespawnTickets_East)
+            QGVAR(IndividualRespawnTickets_East)
         };
         case independent: {
-            GVAR(IndividualRespawnTickets_Ind)
+            QGVAR(IndividualRespawnTickets_Ind)
         };
         case civilian: {
-            GVAR(IndividualRespawnTickets_Civ)
-        };
-        default {
-            -1
+            QGVAR(IndividualRespawnTickets_Civ)
         };
     };
-    if (_indTicketVar isEqualTo -1 || _indTicketVar > 0) then {
-        _indTicketVar = _indTicketVar - 1;
+    if ((missionNamespace getVariable [_indTicketVar, -1]) isEqualTo -1 || (missionNamespace getVariable [_indTicketVar, -1]) > 0) then {
+        if ((missionNamespace getVariable [_indTicketVar, -1]) > 0) then {
+            missionNamespace setVariable [_indTicketVar, (missionNamespace getVariable [_indTicketVar, -1]) - 1];
+        };
         LOG_1("eventCheckRespawnTickets called: %1",_unit);
         [QGVAR(eventCheckRespawnTickets), _unit] call CBA_fnc_serverEvent;
     } else {

--- a/core/preinitClient.sqf
+++ b/core/preinitClient.sqf
@@ -161,11 +161,72 @@ FUNC(eg_keyHandler2) = {
                     0
                 };
         	};
-        	private _p = "";
-        	if (_sideTickets != 1) then {
-        		_p = "s";
+            if (_sideTickets isEqualTo 0) then {
+                cutText ['Your side has no tickets left, you can not respawn', 'PLAIN DOWN'];
+        	} else {
+                private _p = "";
+                if (_sideTickets != 1) then {
+            		_p = "s";
+            	};
+                cutText [format ['Your side has %1 ticket%2 left, you can respawn %1 time%2', _sideTickets, _p], 'PLAIN DOWN'];
+            };
+        };
+        case 2: {
+            private _sideTickets = switch (side player) do {
+        		case west: {
+        			GVAR(RespawnTickets_West)
+        		};
+        		case east: {
+        			GVAR(RespawnTickets_East)
+        		};
+        		case independent: {
+        			GVAR(RespawnTickets_Ind)
+        		};
+        		case civilian: {
+        			GVAR(RespawnTickets_Civ)
+        		};
+                default {
+                    0
+                };
         	};
-        	cutText [format ['Your side has %1 ticket%2 left, you can respawn %1 time%2', _sideTickets, _p], 'PLAIN DOWN'];
+            private _indTickets = switch (side player) do {
+                case west: {
+                    GVAR(IndividualRespawnTickets_West)
+                };
+                case east: {
+                    GVAR(IndividualRespawnTickets_East)
+                };
+                case independent: {
+                    GVAR(IndividualRespawnTickets_Ind)
+                };
+                case civilian: {
+                    GVAR(IndividualRespawnTickets_Civ)
+                };
+                default {
+                    0
+                };
+            };
+            if (_sideTickets isEqualTo 0) then {
+                cutText ['Your side has no tickets left, you can not respawn', 'PLAIN DOWN'];
+        	} else {
+                if (_indTickets isEqualTo 0) then {
+                    cutText ['You have no individual tickets left, you can not respawn', 'PLAIN DOWN'];
+            	} else {
+                    private _pS = "";
+                    if (_sideTickets isNotEqualTo 1) then {
+                		_pS = "s";
+                	};
+                    private _pI = "";
+                    if (_indTickets isNotEqualTo 1) then {
+                		_pI = "s";
+                	};
+                    if (_indTickets >= _sideTickets) then {
+                        cutText [format ['You have %1 individual ticket%2 left and your team has %3 ticket%4 left, you can respawn %3 time%4', _indTickets, _pI, _sideTickets, _pS], 'PLAIN DOWN'];
+                    } else {
+                        cutText [format ['You have %1 individual ticket%2 left and your team has %3 ticket%4 left, you can respawn %1 time%2', _indTickets, _pI, _sideTickets, _pS], 'PLAIN DOWN'];
+                    };
+                };
+            };
         };
         default {};
     };
@@ -175,7 +236,25 @@ FUNC(eg_keyHandler2) = {
     params [["_response", false, [false]]];
     LOG_2("eventCheckRespawnTickets_Response started: %1 response: %2",player,_response);
     if (_response) then {
-        [QGVAR(eventPlayerRespawned), [1]] call CBA_fnc_localEvent;
+        private _indTicketVar = switch (side player) do {
+            case west: {
+                QGVAR(IndividualRespawnTickets_West)
+            };
+            case east: {
+                QGVAR(IndividualRespawnTickets_East)
+            };
+            case independent: {
+                QGVAR(IndividualRespawnTickets_Ind)
+            };
+            case civilian: {
+                QGVAR(IndividualRespawnTickets_Civ)
+            };
+        };
+        if ((missionNamespace getVariable [_indTicketVar, -1]) isEqualTo -1) then {
+            [QGVAR(eventPlayerRespawned), [1]] call CBA_fnc_localEvent;
+        } else {
+            [QGVAR(eventPlayerRespawned), [2]] call CBA_fnc_localEvent;
+        };
     } else {
         [] call FUNC(StartSpectator); // spectator var is set in this function
         [QGVAR(respawnEvent), [player, true]] call CBA_fnc_serverEvent;

--- a/core/preinitClient.sqf
+++ b/core/preinitClient.sqf
@@ -146,16 +146,16 @@ FUNC(eg_keyHandler2) = {
         case 1: {
             private _sideTickets = switch (side player) do {
         		case west: {
-        			GVAR(RespawnTicketsWest)
+        			GVAR(RespawnTickets_West)
         		};
         		case east: {
-        			GVAR(RespawnTicketsEast)
+        			GVAR(RespawnTickets_East)
         		};
         		case independent: {
-        			GVAR(RespawnTicketsInd)
+        			GVAR(RespawnTickets_Ind)
         		};
         		case civilian: {
-        			GVAR(RespawnTicketsCiv)
+        			GVAR(RespawnTickets_Civ)
         		};
                 default {
                     0

--- a/core/preinitClient.sqf
+++ b/core/preinitClient.sqf
@@ -130,6 +130,9 @@ FUNC(eg_keyHandler2) = {
 	};
 
     player setVariable [QGVAR(Body), player, true];
+    player setVariable [QGVAR(HasDied), false, true];
+    player setVariable [QGVAR(Dead), false, true];
+	[QGVAR(respawnEvent), [player]] call CBA_fnc_serverEvent;
 
     switch (_respawnType) do {
         case -1: {

--- a/core/preinitServer.sqf
+++ b/core/preinitServer.sqf
@@ -37,8 +37,8 @@ GVAR(MissionEnded) = false; //Mission has not ended
     private _canRespawn = false;
     switch (_side) do {
         case west: {
-            if (GVAR(RespawnTicketsWest) > 0) then {
-                GVAR(RespawnTicketsWest) = GVAR(RespawnTicketsWest) - 1;
+            if (GVAR(RespawnTickets_West) > 0) then {
+                GVAR(RespawnTickets_West) = GVAR(RespawnTickets_West) - 1;
                 GVAR(CurrentWaveCountWest) = GVAR(CurrentWaveCountWest) + 1;
                 if (GVAR(CurrentWaveCountWest) >= GVAR(WaveSizeWest) && {!(GVAR(RespawnPenGateWest) isEqualTo objnull)}) then {
                     GVAR(CurrentWaveUnlockedWest) = true;
@@ -53,8 +53,8 @@ GVAR(MissionEnded) = false; //Mission has not ended
             };
         };
         case east: {
-            if (GVAR(RespawnTicketsEast) > 0) then {
-                GVAR(RespawnTicketsEast) = GVAR(RespawnTicketsEast) - 1;
+            if (GVAR(RespawnTickets_East) > 0) then {
+                GVAR(RespawnTickets_East) = GVAR(RespawnTickets_East) - 1;
                 GVAR(CurrentWaveCountEast) = GVAR(CurrentWaveCountEast) + 1;
                 if (GVAR(CurrentWaveCountEast) >= GVAR(WaveSizeEast) && {!(GVAR(RespawnPenGateEast) isEqualTo objnull)}) then {
                     GVAR(CurrentWaveUnlockedEast) = true;
@@ -69,8 +69,8 @@ GVAR(MissionEnded) = false; //Mission has not ended
             };
         };
         case independent: {
-            if (GVAR(RespawnTicketsInd) > 0) then {
-                GVAR(RespawnTicketsInd) = GVAR(RespawnTicketsInd) - 1;
+            if (GVAR(RespawnTickets_Ind) > 0) then {
+                GVAR(RespawnTickets_Ind) = GVAR(RespawnTickets_Ind) - 1;
                 GVAR(CurrentWaveCountInd) = GVAR(CurrentWaveCountInd) + 1;
                 if (GVAR(CurrentWaveCountInd) >= GVAR(WaveSizeInd) && {!(GVAR(RespawnPenGateInd) isEqualTo objnull)}) then {
                     GVAR(CurrentWaveUnlockedInd) = true;
@@ -85,8 +85,8 @@ GVAR(MissionEnded) = false; //Mission has not ended
             };
         };
         case civilian: {
-            if (GVAR(RespawnTicketsCiv) > 0) then {
-                GVAR(RespawnTicketsCiv) = GVAR(RespawnTicketsCiv) - 1;
+            if (GVAR(RespawnTickets_Civ) > 0) then {
+                GVAR(RespawnTickets_Civ) = GVAR(RespawnTickets_Civ) - 1;
                 GVAR(CurrentWaveCountCiv) = GVAR(CurrentWaveCountCiv) + 1;
                 if (GVAR(CurrentWaveCountCiv) >= GVAR(WaveSizeCiv) && {!(GVAR(RespawnPenGateCiv) isEqualTo objnull)}) then {
                     GVAR(CurrentWaveUnlockedCiv) = true;
@@ -112,7 +112,7 @@ GVAR(MissionEnded) = false; //Mission has not ended
     } else {
         [_magazine] call FUNC(getDisplayName);
     };
-    TRACE_3("count event",_magName,_magazine,_projectile);
+    TRACE_3("count event",_magName,(_magazine),_projectile);
     [_side, _magName] call FUNC(shotCount);
 }] call CBA_fnc_addEventHandler;
 

--- a/customization/clientSettings.sqf
+++ b/customization/clientSettings.sqf
@@ -8,6 +8,13 @@ GVAR(StartOnSafe_Unloaded) = false;
 
 GVAR(RespawnTickets) = 0; //Initialize individual client respawn tickets to 0
 
+// Individual Tickets for different sides when team respawn is enabled in serverSettings
+// set to -1 for unlimited individual tickets
+GVAR(IndividualRespawnTickets_West) = -1;
+GVAR(IndividualRespawnTickets_East) = -1;
+GVAR(IndividualRespawnTickets_Ind) = -1;
+GVAR(IndividualRespawnTickets_Civ) = -1;
+
 //call FUNC(forceTerrainGrid); //uncomment this to force high terrain setting. This will prevent faraway objects from appearing as floating. Useful for missions with long sightlines.
 
 // Spectator Settings

--- a/customization/serverSettings.sqf
+++ b/customization/serverSettings.sqf
@@ -14,19 +14,14 @@ GVAR(DisconnectBodyCleanupTime) = 2;
 GVAR(DisconnectBodyCleanupSides) = [WEST, EAST, INDEPENDENT, CIVILIAN];
 
 /*
-If respawn is enabled you must create empty game logics, for respawn points, following the name format GVAR(side_respawn). Example: FW_west_respawn
-Ticket pools for different sides
+    If respawn is enabled you must create empty game logics, for respawn points, following the name format GVAR(side_respawn). Example: FW_west_respawn
+    Ticket pools for different sides
+    Set individual tickets for players on a side in clientSettings
 */
 GVAR(RespawnTickets_West) = 0;
 GVAR(RespawnTickets_East) = 0;
 GVAR(RespawnTickets_Ind) = 0;
 GVAR(RespawnTickets_Civ) = 0;
-
-//Individual Tickets for different sides 
-GVAR(IndividualRespawnTickets_West) = 0;
-GVAR(IndividualRespawnTickets_East) = 0;
-GVAR(IndividualRespawnTickets_Ind) = 0;
-GVAR(IndividualRespawnTickets_Civ) = 0;
 
 //wave respawn
 GVAR(WaveSizeWest) = 0; //How many players have to respawn before wave is released


### PR DESCRIPTION
- Fixes casualty count on respawn (tracking of respawned unit, hasDied/Dead variables set)
- Implements individual tickets for clients while team tickets are enabled (maximum tickets on a team that a player can use)

NOT WORKING:
- hints to player informing them of how many tickets they have left, if they can respawn again. (works on local/editor MP, not on server)