### PR TITLE
Fix preprecessor macros, empty vehicle param order

### DIFF
--- a/description.ext
+++ b/description.ext
@@ -9,6 +9,11 @@
 #undef false
 #undef description
 
+#define description_other
+#include "core\description.hpp" //DO NOT REMOVE
+#include "modules\modules.sqf" //DO NOT REMOVE
+#undef description_other
+
 class CfgFunctions {
 	class FW {
 		tag = "FW";

--- a/modules/headless_ai/cfgFunctions/GetInfo/fn_getDetailsVehicleEmpty.sqf
+++ b/modules/headless_ai/cfgFunctions/GetInfo/fn_getDetailsVehicleEmpty.sqf
@@ -20,6 +20,7 @@ private _fuel = parseNumber (fuel _veh toFixed 2);
 private _vehCustomization = _veh call BIS_fnc_getVehicleCustomization;
 private _name = GETVAR(_veh,varName,"");
 private _olsenGearType = GETVAR(_veh,gearType,"");
+
 [typeOf _veh,
 _pos,
 _vectorDir,
@@ -29,7 +30,6 @@ _fuel,
 magazinesAllTurrets _veh,
 locked _veh,
 surfaceIsWater (getposATL _veh),
-(GETVAR(_veh,Name,"")),
 _init,
 (GETVAR(_veh,StoredVars,[])),
 _vehCustomization,

--- a/modules/headless_ai/cfgFunctions/GetInfo/fn_getSyncedObjects.sqf
+++ b/modules/headless_ai/cfgFunctions/GetInfo/fn_getSyncedObjects.sqf
@@ -16,7 +16,7 @@ _uniqueSynced apply {
     if (_obj isKindOf "Logic") then {
     } else {
         if (_obj isKindOf "Thing") then {
-            _objects pushBack ([_obj] call FUNC(getDetailsThing));
+            _objects pushBackUnique ([_obj] call FUNC(getDetailsThing));
         } else {
             if (_obj isKindOf "Man") then {
                 private _group = group _obj;
@@ -62,7 +62,7 @@ _uniqueSynced apply {
                             };
                         } else {
                             private _unitArray = [_unit,_unitpos] call FUNC(getDetailsUnit);
-                            (_groupArray select 2) pushBack _unitArray;
+                            (_groupArray select 2) pushBackUnique _unitArray;
                         };
                     };
                     private _occupy = ((_groupArray select 1) select 15);
@@ -71,7 +71,7 @@ _uniqueSynced apply {
                     private _currentPos = ((_groupArray select 1) select 1);
                     for "_g" from 0 to _gx step 1 do {
                         if (_newOccupy isEqualTo 0 && {_gx isEqualTo 0}) then {
-                            _groups pushBack _groupArray;
+                            _groups pushBackUnique _groupArray;
                         } else {
                             if (_gx > 0) then {
                                 if (!(_groupPosArray isEqualTo [])) then {
@@ -115,7 +115,7 @@ _uniqueSynced apply {
                     {_obj isKindOf "Static"}}}}
                 ) then {
                     if (crew _obj isEqualTo []) then {
-                        _emptyVehs pushBack ([_obj] call FUNC(getDetailsVehicleEmpty));
+                        _emptyVehs pushBackUnique ([_obj] call FUNC(getDetailsVehicleEmpty));
                     };
                 };
             };

--- a/modules/headless_ai/cfgFunctions/create/fn_createEmptyVehicle.sqf
+++ b/modules/headless_ai/cfgFunctions/create/fn_createEmptyVehicle.sqf
@@ -2,7 +2,6 @@
 
 params [
     ["_vehClass", "", [""]],
-    ["_vehCrew", [], [[]]],
     ["_pos", [], [[]]],
     ["_vectorDir", [], [[]]],
     ["_vectorUp", [], [[]]],

--- a/modules/headless_ai/cfgFunctions/create/fn_createEmptyVehicle.sqf
+++ b/modules/headless_ai/cfgFunctions/create/fn_createEmptyVehicle.sqf
@@ -9,9 +9,8 @@ params [
     ["_fuel", 100, [100]],
     ["_turretMags", [], [[]]],
     ["_locked", 0, [0]],
+    ["_surfaceIsWater", false, [false]],
     ["_init", false, [false,{}]],
-    ["_fly", false, [false]],
-    ["_flyInHeight", 200, [200]],
     ["_storedVars", [], [[]]],
     ["_vehCustomization", [], [[]]],
     ["_varName", "", [""]],
@@ -28,7 +27,7 @@ if (_varName isNotEqualTo "") then {
 };
 
 if (_olsenGearType isNotEqualTo "") then {
-    [_vehicle, _olsenGearType] call FUNC(VehicleGearScript);
+    [_vehicle, _olsenGearType] call EFUNC(FW,VehGearScript);
 };
 
 _vehicle setDamage _damage;

--- a/modules/headless_ai/cfgFunctions/create/fn_createVehicle.sqf
+++ b/modules/headless_ai/cfgFunctions/create/fn_createVehicle.sqf
@@ -63,7 +63,7 @@ if (_varName isNotEqualTo "") then {
 };
 
 if (_olsenGearType isNotEqualTo "") then {
-    [_vehicle, _olsenGearType] call FUNC(VehicleGearScript);
+    [_vehicle, _olsenGearType] call FUNC(VehGearScript);
 };
 
 if (_fly) then {

--- a/modules/headless_ai/root.sqf
+++ b/modules/headless_ai/root.sqf
@@ -1,8 +1,11 @@
 #include "script_macros.hpp"
 
 #ifdef description
-	#include "StateMachines.hpp"
 	#include "CfgRemoteExec.hpp"
+#endif
+
+#ifdef description_other
+    #include "StateMachines.hpp"
 #endif
 
 #ifdef description_external_functions


### PR DESCRIPTION
- remove vehcrew from empty vehicle
- pushbackUnique vehicle pushback
- move statemachines and other fnc in config to description_other header 
- vehGearScript call fix
-  fix duplicate params in emptyVehicle fnc