### PR TITLE
anti nd module option to disable quick throwing for the mission

### DIFF
--- a/modules/anti_nd/preinitClient.sqf
+++ b/modules/anti_nd/preinitClient.sqf
@@ -13,4 +13,6 @@ GVAR(INDFOR_Distance) = [missionConfigFile >> QGVAR(settings) >> "INDFOR" >> "di
 GVAR(CIV_Time) = [missionConfigFile >> QGVAR(settings) >> "CIV" >> "time", "number", 30] call CBA_fnc_getConfigEntry;
 GVAR(CIV_Distance) = [missionConfigFile >> QGVAR(settings) >> "CIV" >> "distance", "number", 200] call CBA_fnc_getConfigEntry;
 
+GVAR(disableQuickGrenades) = ([missionConfigFile >> QGVAR(settings) >> "disableQuickGrenades", "number", 1] call CBA_fnc_getConfigEntry) == 1;
+
 [] call FUNC(Init);

--- a/modules/anti_nd/settings.hpp
+++ b/modules/anti_nd/settings.hpp
@@ -8,6 +8,8 @@
 
 // If you want to disable a setting, set it to 0.
 
+disableQuickGrenades = true;
+
 class BLUFOR {
     time = 60;
     distance = 200;

--- a/modules/anti_nd/settings.hpp
+++ b/modules/anti_nd/settings.hpp
@@ -6,10 +6,11 @@
 // Distance:
 // Distance is recommended for regular assault missions.
 
-// If you want to disable a setting, set it to 0.
-
+// Disables quick grenades (default G to throw item) and only enables ACE throwing.
+// User will get an annoying message if they do not have their grenade key unbound and attempt to throw.
 disableQuickGrenades = true;
 
+// If you want to disable a setting for a team, set it to 0.
 class BLUFOR {
     time = 60;
     distance = 200;


### PR DESCRIPTION

- option to disable quick throw (grenade throw button) in a mission
- still allows for ACE advanced throwing, only affects vanilla quick throw

- `disableQuickGrenades` setting in `modules\anti_nd\settings.hpp`, default is true (disabled quick throw)