### PR TITLE
soft Mission End

### DIFF
--- a/core/CfgFunctions.hpp
+++ b/core/CfgFunctions.hpp
@@ -28,6 +28,7 @@ class Core {
 	class registerModule {};
 	class removeAllGear {};
 	class removeAllVehicleGear {};
+    class softEndMission {};
 	class parsedTextDisplay {};
 	class spectatePrep {};
 	class trackAsset {};

--- a/core/functions/fn_softEndMission.sqf
+++ b/core/functions/fn_softEndMission.sqf
@@ -1,0 +1,27 @@
+#include "script_component.hpp"
+
+params [
+    ["_endText", "", [""]],
+    ["_warnText", "", [""]],
+    ["_time", 10, [0]]
+];
+
+if (_warnText isEqualTo "") then {
+    _warnText = _endText;
+};
+
+if (_time < 5) then {
+    _time = 5;
+};
+
+[
+    _warnText,
+    0,
+    0.25,
+    _time,
+    1
+] spawn BIS_fnc_dynamicText;
+
+[{
+    _this call FUNC(endMission);
+}, [_endText], _time] call CBA_fnc_waitAndExecute;

--- a/customization/endConditions.sqf
+++ b/customization/endConditions.sqf
@@ -10,6 +10,15 @@ if (_eastCasualty >= 75) exitWith {
 };
 
 /*
+Soft Ending the Mission
+    Missions can be "soft" ended via the FUNC(SoftEndMission) function.
+    The mission end warn message will display first, then count down the time to end, then display
+    the regular endmission screen. Minimum time to wait is 5 seconds. If no warn message is given, eg:
+    ["USMC VICTORY<br />VDV has retreated due to casualties.", "", 30] call FUNC(SoftEndMission);
+    then function uses the regular end mission text as the warn message as well.
+    [<MISSION END MESSAGE: STRING>, <MISSION END WARN MESSAGE: STRING | OPTIONAL>, <TIME TO WAIT: NUMBER | OPTIONAL>] call FUNC(SoftEndMission);
+    eg. ["USMC VICTORY<br />VDV has retreated due to casualties.", "USMC VICTORY", 30] call FUNC(SoftEndMission);
+
 Alternative methods of counting casualties
 
 	"USMC" call FUNC(casualtyCount);
@@ -19,7 +28,6 @@ Alternative methods of counting casualties
 		this will check how many players are remaining in a team
 		be careful as using this method will end the mission instantly if
 		not enough players are present in the team
-
 
 Adding extraction
 


### PR DESCRIPTION
Missions can be "soft" ended via the FUNC(SoftEndMission) function.
The mission end warn message will display first, then count down the time to end, then display
the regular endmission screen. Minimum time to wait is 5 seconds. If no warn message is given, eg:
```sqf
["USMC VICTORY<br />VDV has retreated due to casualties.", "", 30] call FUNC(SoftEndMission);
```
then function uses the regular end mission text as the warn message as well.
```sqf
[
 <MISSION END MESSAGE: STRING>, 
 <MISSION END WARN MESSAGE: STRING | OPTIONAL>, 
 <TIME TO WAIT: NUMBER | OPTIONAL>
] call FUNC(SoftEndMission);
```
eg. 
```sqf
["USMC VICTORY<br />VDV has retreated due to casualties.", "USMC VICTORY", 30] call FUNC(SoftEndMission);
```

Closes #231 