### PR TITLE
Dev

### DIFF
--- a/core/functions/fn_briefing.sqf
+++ b/core/functions/fn_briefing.sqf
@@ -23,7 +23,7 @@ private _playerBriefing = switch (side player) do {
 	case west: {_westBriefing};
 	case east: {_eastBriefing};
 	case independent: {_indBriefing};
-	case civilian: {_civBriefing};
+	default {_civBriefing};
 };
 
 private _briefing = [];

--- a/core/preinitClient.sqf
+++ b/core/preinitClient.sqf
@@ -156,8 +156,7 @@ FUNC(eg_keyHandler2) = {
             case west: {"fw_west_respawn"};
             case east: {"fw_east_respawn"};
             case independent: {"fw_ind_respawn"};
-            case civilian: {"fw_civ_respawn"};
-            default {""};
+            default {"fw_civ_respawn"};
         };
     	private _respawnPoint = missionNamespace getVariable [_respawnName, objNull];
         if (_respawnPoint isNotEqualTo objnull) then {

--- a/core/script_macros.hpp
+++ b/core/script_macros.hpp
@@ -2,11 +2,11 @@
 #ifndef COMPONENT
     #define COMPONENT FW
 #endif
-#define DEBUG_MODE_NORMAL
-//#define DEBUG_MODE_FULL
-#define VERSIONSTR "1.1.3"
+//#define DEBUG_MODE_NORMAL
+#define DEBUG_MODE_FULL
+#define VERSIONSTR "1.1.4 DEV"
 #define VERSION 1.1
-#define VERSION_AR 1,1,3
+#define VERSION_AR 1,1,4
 #include "script_macros_mission.hpp"
 
 #define RNG(var1) var1 > random 1

--- a/modules/ai_drivers/settings.hpp
+++ b/modules/ai_drivers/settings.hpp
@@ -31,7 +31,7 @@ target dir pos will determine the angle of the camera in the driver view
 there is a driver view preview display as well as an AI driver that will spawn in so you can adjust around their model
 the view position doesn't need to be exactly where the driver is, up to the mission maker
 */
-TestMode = true;
+TestMode = false;
 
 // customized class config for AI driver view params
 class AIViewParams {

--- a/modules/headless_ai/settings.hpp
+++ b/modules/headless_ai/settings.hpp
@@ -31,14 +31,17 @@ useMarkers = true;
 AIViewDistance = 2500;
 // value between 3.125 and 50, the lower the more terrain detail
 AITerrainDetail = 3.125;
-// Forces Time on the HC to simulate better AI at night [HOUR,MINUTE]
-forceTimeEnable = true;
+/* Forces Time on the HC to simulate better AI at night [HOUR,MINUTE]
+This setting should only be used to either increase AI sighting ability at night or to make the AI slower to detect in the day time
+There is no need to enable this setting if you are in the day time and want the AI to react as if it is the day time, likewise if it is night and you want the typical
+night behaviour. forceTime is the time in hour, then minute. */
+forceTimeEnable = false;
 forceTime[] = {12,00};
 
 // AI system options
 feature = true;
 enemyUpdateFrequency = 5;
-stateMachineFrames = 2;
+stateMachineFrames = 1;
 //attempts to find a better safe area for a vehicle to spawn in. Should only be used when neccessary.
 saferVehSpawning = false;
 

--- a/readme.MD
+++ b/readme.MD
@@ -3,7 +3,7 @@
 </p>
 <p align="center">
     <a href="https://github.com/Global-Conflicts-ArmA/Olsen-Framework-Arma-3/releases/latest">
-        <img src="https://img.shields.io/badge/Version-1.1.3-blue.svg" alt="Global Conflicts Framework Version">
+        <img src="https://img.shields.io/badge/Version-1.1.4-blue.svg" alt="Global Conflicts Framework Version">
     </a>
     <a href="https://github.com/Global-Conflicts-ArmA/Olsen-Framework-Arma-3/issues">
         <img src="https://img.shields.io/github/issues-raw/Global-Conflicts-ArmA/Olsen-Framework-Arma-3.svg?label=Issues" alt="Global Conflicts Framework Issues">


### PR DESCRIPTION
- changed default AI driver test mode settingg
- disabled ForceTimeEnable
- Included description of forceTime feature
- turned default stateMachineFrames to 1 (*slightly* slower AI reaction time, less strain on HC)
- default case for logic side spectators/zeus 
