### PR TITLE
soft end with just message for GM ending

### DIFF
--- a/core/functions/fn_softEndMission.sqf
+++ b/core/functions/fn_softEndMission.sqf
@@ -10,6 +10,8 @@ if (_warnText isEqualTo "") then {
     _warnText = _endText;
 };
 
+private _endMission = !(_time isEqualTo -1);
+
 if (_time < 5) then {
     _time = 5;
 };
@@ -25,6 +27,8 @@ if (_time < 5) then {
     ] spawn BIS_fnc_dynamicText;
 }] remoteExec ["BIS_fnc_call", 0, true];
 
-[{
-    _this call FUNC(endMission);
-}, [_endText], _time] call CBA_fnc_waitAndExecute;
+if (_endMission) then {
+    [{
+        _this call FUNC(endMission);
+    }, [_endText], _time] call CBA_fnc_waitAndExecute;
+};

--- a/customization/endConditions.sqf
+++ b/customization/endConditions.sqf
@@ -19,6 +19,9 @@ Soft Ending the Mission
     [<MISSION END MESSAGE: STRING>, <MISSION END WARN MESSAGE: STRING | OPTIONAL>, <TIME TO WAIT: NUMBER | OPTIONAL>] call FUNC(SoftEndMission);
     eg. ["USMC VICTORY<br />VDV has retreated due to casualties.", "USMC VICTORY", 30] call FUNC(SoftEndMission);
 
+    If you want the mission to only display the end mission, and for it only to end when a GM calls it, set the time to wait to -1
+    eg. ["USMC VICTORY<br />VDV has retreated due to casualties.", "USMC VICTORY", -1] call FUNC(SoftEndMission);
+
 Alternative methods of counting casualties
 
 	"USMC" call FUNC(casualtyCount);


### PR DESCRIPTION
- soft end with just message for GM ending 

If you want the mission to only display the end mission, and for it only to end when a GM calls it, set the time to wait to -1
eg. `["USMC VICTORY<br />VDV has retreated due to casualties.", "USMC VICTORY", -1] call FUNC(SoftEndMission);`