### PR TITLE
force false settings on servername with "main" string

### DIFF
--- a/core/preinit.sqf
+++ b/core/preinit.sqf
@@ -3,7 +3,14 @@
 #include "script_macros.hpp"
 
 // debug settings
-GVAR(testingDisableFriendlyAI) = ([missionConfigFile >> QGVAR(debugSettings) >> "testingDisableFriendlyAI", "number", 0] call CBA_fnc_getConfigEntry) == 1;
+if (
+    isMultiplayer &&
+    {(toLower serverName) find "main" isNotEqualTo -1}
+) then {
+    GVAR(testingDisableFriendlyAI) = false;
+} else {
+    GVAR(testingDisableFriendlyAI) = ([missionConfigFile >> QGVAR(debugSettings) >> "testingDisableFriendlyAI", "number", 0] call CBA_fnc_getConfigEntry) == 1;
+};
 
 // gear settings
 GVAR(force_remove_facewear) = ([missionConfigFile >> QGVAR(gearSettings) >> "forceRemoveFacewear", "number", 0] call CBA_fnc_getConfigEntry) == 1;

--- a/core/preinitClient.sqf
+++ b/core/preinitClient.sqf
@@ -3,7 +3,15 @@
 #define preInitClient
 
 // Debug settings
-GVAR(debugMessagesEnabled) = ([missionConfigFile >> QGVAR(debugSettings) >> "debugMessagesEnabled", "number", 1] call CBA_fnc_getConfigEntry) == 1;
+if (
+    isMultiplayer &&
+    {(toLower serverName) find "main" isNotEqualTo -1}
+) then {
+    GVAR(debugMessagesEnabled) = false;
+} else {
+    GVAR(debugMessagesEnabled) = ([missionConfigFile >> QGVAR(debugSettings) >> "debugMessagesEnabled", "number", 1] call CBA_fnc_getConfigEntry) == 1;
+};
+
 GVAR(DiaryRecords) = [];
 
 // Start on Safe settings

--- a/modules/headless_ai/preInitGlobal.sqf
+++ b/modules/headless_ai/preInitGlobal.sqf
@@ -7,10 +7,20 @@ GVAR(InitialSpawn) = [missionConfigFile >> QGVAR(settings) >> "initialSpawn", "a
 GVAR(InitialRandomSpawns) = [missionConfigFile >> QGVAR(settings) >> "initialRandomSpawns", "array", []] call CBA_fnc_getConfigEntry;
 GVAR(InitialRandomSpawnsCount) = [missionConfigFile >> QGVAR(settings) >> "initialRandomSpawnsCount", "number", 0] call CBA_fnc_getConfigEntry;
 
-GVAR(debug) = ([missionConfigFile >> QGVAR(settings) >> "debug", "number", 1] call CBA_fnc_getConfigEntry) == 1;
-GVAR(verboseDebug) = ([missionConfigFile >> QGVAR(settings) >> "verboseDebug", "number", 1] call CBA_fnc_getConfigEntry) == 1;
-GVAR(groupDebug) = ([missionConfigFile >> QGVAR(settings) >> "groupDebug", "number", 1] call CBA_fnc_getConfigEntry) == 1;
-GVAR(useMarkers) = ([missionConfigFile >> QGVAR(settings) >> "useMarkers", "number", 1] call CBA_fnc_getConfigEntry) == 1;
+if (
+    isMultiplayer &&
+    {(toLower serverName) find "main" isNotEqualTo -1}
+) then {
+    GVAR(debug) = false;
+    GVAR(verboseDebug) = false;
+    GVAR(groupDebug) = false;
+    GVAR(useMarkers) = false;
+} else {
+    GVAR(debug) = ([missionConfigFile >> QGVAR(settings) >> "debug", "number", 1] call CBA_fnc_getConfigEntry) == 1;
+    GVAR(verboseDebug) = ([missionConfigFile >> QGVAR(settings) >> "verboseDebug", "number", 1] call CBA_fnc_getConfigEntry) == 1;
+    GVAR(groupDebug) = ([missionConfigFile >> QGVAR(settings) >> "groupDebug", "number", 1] call CBA_fnc_getConfigEntry) == 1;
+    GVAR(useMarkers) = ([missionConfigFile >> QGVAR(settings) >> "useMarkers", "number", 1] call CBA_fnc_getConfigEntry) == 1;
+};
 
 GVAR(AIViewDistance) = [missionConfigFile >> QGVAR(settings) >> "AIViewDistance", "number", 2500] call CBA_fnc_getConfigEntry;
 GVAR(AITerrainDetail) = [missionConfigFile >> QGVAR(settings) >> "AIViewDistance", "number", 3.125] call CBA_fnc_getConfigEntry;


### PR DESCRIPTION
Forces debug settings to false on the main server in case mission makers forget to turn them off. 

- applies to core settings `debugMessagesEnabled`, `testingDisableFriendlyAI` 
- applies to HC settings `debug`, `verboseDebug`, `groupDebug`, `useMarkers`
