### PR TITLE
Bugfix/itc setting

### DIFF
--- a/core/preinit.sqf
+++ b/core/preinit.sqf
@@ -21,6 +21,9 @@ GVAR(removeAllGear) = ([missionConfigFile >> QGVAR(gearSettings) >> "testingDisa
 GVAR(loadingScreen) = ([missionConfigFile >> QGVAR(settings) >> "loadingScreen", "number", 1] call CBA_fnc_getConfigEntry) == 1;
 ace_respawn_RemoveDeadBodiesDisconnected = ([missionConfigFile >> QGVAR(settings) >> "removeDeadBodiesDisconnected", "number", 0] call CBA_fnc_getConfigEntry) == 1;
 
+// ITC settings
+ITC_LAND_CIWS_INTERCEPTABLE = [missionConfigFile >> QGVAR(settings) >> "interceptableMissiles", "ARRAY", []] call CBA_fnc_getConfigEntry;
+
 GVAR(DebugMessages) = [];
 GVAR(Modules) = [];
 

--- a/customization/settings.hpp
+++ b/customization/settings.hpp
@@ -1,3 +1,11 @@
 removeDeadBodiesDisconnected = false; //this disables automatically removing bodies
 
 loadingScreen = true;
+
+/* 
+ITC anti missile targeting ability setting
+Adding classname strings to this will allow CWIS and other anti missile units to target these classes of missiles
+eg. interceptableMissiles[] = {"Sh_82mm_AMOS_guided"};
+Default to none with feature disabled
+*/
+interceptableMissiles[] = {};


### PR DESCRIPTION
- Adds default setting for ITC interceptable missiles to nothing IOT prevent trigger activation from munitions
- interceptableMissiles setting in main settings file to set ITC interceptable missiles on a class by class basis