### PR TITLE
fixed initialRandomSpawns sometimes selecting same element twice

### DIFF
--- a/modules/headless_ai/functions/Main/fn_initMain.sqf
+++ b/modules/headless_ai/functions/Main/fn_initMain.sqf
@@ -76,8 +76,9 @@ if ((GVAR(InitialRandomSpawnsCount) >= 1) && {(GVAR(InitialRandomSpawns) isNotEq
 		private _initialRandomSpawnsSelected = [];
 		for "_a" from 1 to (GETMVAR(InitialRandomSpawnsCount,1)) step 1 do {
 		    private _selected = selectRandomWeighted _initialRandomSpawns;
+			_index = _initialRandomSpawns find _selected;
 			_initialRandomSpawnsSelected pushBackUnique _selected;
-			_initialRandomSpawns - [_selected];
+			_initialRandomSpawns deleteRange [_index, 2];
 		};
 		if (_initialRandomSpawnsSelected isNotEqualTo []) then {
 			[{


### PR DESCRIPTION
Another small one. Initial random spawns would sometimes select the same element twice, resulting in one fewer than intended random spawns due to pushBackUnique being used here.

This fix uses deleteRange since Array subtraction apparently doesn't modify the original array in sqf, and also removes the weighting in addition to the selection.