### PR TITLE
refactor assault/retreat behaviour to use tasks more consistently in commanderAI

### DIFF
--- a/modules/headless_ai/functions/CfgFunctions.hpp
+++ b/modules/headless_ai/functions/CfgFunctions.hpp
@@ -28,8 +28,8 @@ class COMPONENT {
 		class ArmEmptyStatic {};
 		class combatAmbientFire {};
 		class CombatAttack {};
-		class CombatAssault {};
 		class CombatAssaultVehicle {};
+		class CombatBound {};
 		class CombatCover {};
 		class CombatCoverVehicle {};
 		class CombatDefend {};
@@ -249,6 +249,7 @@ class COMPONENT {
 	    class taskLoiter {};
 	    class taskHoldUntil {};
 	    class taskRelease {};
+		class taskRetreat {};
 	    class taskSearchNearby {};
 	    class taskPickup {};
 	    class taskHunt {};

--- a/modules/headless_ai/functions/Combat/fn_CombatAssaultVehicle.sqf
+++ b/modules/headless_ai/functions/Combat/fn_CombatAssaultVehicle.sqf
@@ -73,7 +73,7 @@ private _assaultTaskPFH = [{
         } ||
         {
             (((side _leader call FUNC(EnemyArray)) findif {
-                ((_leader distance2D _x) <= (GETVAR(_group,AssaultEngageDistance,200))) &&
+                ((_leader distance2D _x) <= (GETVAR(_group,engageDistance,200))) &&
                 {[_leader, _x] call FUNC(LOSCheck)}
             }) isNotEqualTo -1)
         } ||

--- a/modules/headless_ai/functions/Combat/fn_CombatAttack.sqf
+++ b/modules/headless_ai/functions/Combat/fn_CombatAttack.sqf
@@ -3,7 +3,7 @@
 params ["_group", "_targetPos", ["_radius", 50, [50]]];
 
 // rewrite combat attack function to be more aggressive - or completely replace with assault
-[_group, _targetPos, _radius] call FUNC(combatAssault);
+[_group, _targetPos, _radius] call FUNC(combatBound);
 
 //private _enemyDir = leader _group getDir _targetPos;
 //

--- a/modules/headless_ai/functions/Combat/fn_CombatBound.sqf
+++ b/modules/headless_ai/functions/Combat/fn_CombatBound.sqf
@@ -66,7 +66,11 @@ private _boundTaskPFH = [{
         };
     };
     if (
-        ((GETVAR(_group,Task,"PATROL")) isNotEqualTo "ASSAULT" && (GETVAR(_group,Task,"PATROL")) isNotEqualTo "RETREAT") ||
+        (
+            (GETVAR(_group,Task,"PATROL")) isNotEqualTo "ASSAULT" &&
+            (GETVAR(_group,Task,"PATROL")) isNotEqualTo "ATTACK" && 
+            (GETVAR(_group,Task,"PATROL")) isNotEqualTo "RETREAT" 
+        ) ||
         {(GETVAR(_group,ExitBound,false))} ||
         {(getPosATL _leader distance2D _targetPos) <= _compRadius} ||
         {count _units <= 3} ||

--- a/modules/headless_ai/functions/Combat/fn_CombatBound.sqf
+++ b/modules/headless_ai/functions/Combat/fn_CombatBound.sqf
@@ -1,7 +1,7 @@
 #include "script_component.hpp"
 
 params ["_group", "_targetPos", ["_radius", 50, [0]], ["_mode", "ASSAULT", [""]]];
-LOG_1("combatAssault started _this: %1",_this);
+LOG_1("combatBound started _this: %1",_this);
 
 private _leader = leader _group;
 if (INVEHICLE(_leader) && !(vehicle _leader isKindOf "StaticWeapon")) exitWith {
@@ -25,7 +25,7 @@ _units apply {
         _unit disableAI _x;
     };
     _unit setUnitPos "UP";
-    _unit setVariable [QGVAR(Busy), ffalse];
+    _unit setVariable [QGVAR(Busy), false];
     _unit doFollow _leader;
     _unit forceSpeed -1;
     unassignVehicle _unit;
@@ -37,7 +37,7 @@ _group setCombatMode "YELLOW";
 _group setSpeedMode "FULL";
 
 // manoeuvre function
-private _assaultTaskPFH = [{
+private _boundTaskPFH = [{
     params ["_args", "_idPFH"];
     _args params [
         "_group",
@@ -54,6 +54,7 @@ private _assaultTaskPFH = [{
     private _leader = leader _group;
     if (_units isEqualTo []) exitWith {
         [_idPFH] call CBA_fnc_removePerFrameHandler;
+        SETVAR(_group,BoundPFH,objNull);
     };
     private _nearestEnemy = _leader call FUNC(closestEnemy);
     //unset fire and move groups
@@ -65,15 +66,16 @@ private _assaultTaskPFH = [{
         };
     };
     if (
-        (GETVAR(_group,Task,"PATROL")) isNotEqualTo "ASSAULT" ||
-        {(GETVAR(_group,ExitAssault,false))} ||
+        ((GETVAR(_group,Task,"PATROL")) isNotEqualTo "ASSAULT" && (GETVAR(_group,Task,"PATROL")) isNotEqualTo "RETREAT") ||
+        {(GETVAR(_group,ExitBound,false))} ||
         {(getPosATL _leader distance2D _targetPos) <= _compRadius} ||
         {count _units <= 3} ||
         {_mode != "RETREAT" && _leader distance2D _nearestEnemy <= 15}
     ) exitWith {
         [_idPFH] call CBA_fnc_removePerFrameHandler;
-        TRACE_1("Group exited Assault PFH",_group);
-        SETVAR(_group,ExitAssault,false);
+        TRACE_1("Group exited Bound PFH",_group);
+        SETVAR(_group,ExitBound,false);
+        SETVAR(_group,BoundPFH,objNull);
         _group setCombatMode "YELLOW";
         _group setBehaviour "AWARE";
         _group enableAttack true;
@@ -87,14 +89,12 @@ private _assaultTaskPFH = [{
             _unit setUnitPos "AUTO";
             _unit setVariable [QGVAR(Busy), false];
         };
-        //patrol in local area
-        [_group, "PATROL", _targetPos] call FUNC(taskAssign);
     };
     if (_firstRun) then {
-        if (GETVAR(_group,AssaultPFH,objNull) isNotEqualTo objNull) then {
-            [GETVAR(_group,AssaultPFH,objNull)] call CBA_fnc_removePerFrameHandler;
+        if (GETVAR(_group,BoundPFH,objNull) isNotEqualTo objNull) then {
+            [GETVAR(_group,BoundPFH,objNull)] call CBA_fnc_removePerFrameHandler;
         };
-        SETVAR(_group,AssaultPFH,_idPFH);
+        SETVAR(_group,BoundPFH,_idPFH);
         units _group apply {
             private _unit = _x;
             _unit forceSpeed -1;
@@ -113,7 +113,7 @@ private _assaultTaskPFH = [{
     } else {
         if (
             (_nearestEnemy isNotEqualTo objNull) && 
-            {(_leader distance2d _nearestEnemy < (GETVAR(_group,AssaultEngageDistance,200)))}
+            {(_leader distance2d _nearestEnemy < (GETVAR(_group,engageDistance,200)))}
         ) then {
             //sort the members by distance to the objective... find the farthest and make them move, closest do fire support
             // do this if the bound was finished
@@ -133,7 +133,7 @@ private _assaultTaskPFH = [{
                     _fireGroup = _sortArray deleteAt 0;
                     _moveGroup = _sortArray;
                 };
-                TRACE_2("assault groups chosen",_fireGroup,_moveGroup);
+                TRACE_2("bound groups chosen",_fireGroup,_moveGroup);
                 _fireGroup apply {
                     if (RNG(0.5)) then {
                         _x setUnitPos "MIDDLE";
@@ -224,5 +224,3 @@ private _assaultTaskPFH = [{
         };
     };
 }, 3, [_group, _targetPos, _radius]] call CBA_fnc_addPerFrameHandler;
-
-SETVAR(_group,Task,"ASSAULT");

--- a/modules/headless_ai/functions/create/fn_createSubGroup.sqf
+++ b/modules/headless_ai/functions/create/fn_createSubGroup.sqf
@@ -21,6 +21,7 @@ if (GETMVAR(VerboseDebug,false)) then {
 private _group = createGroup _side;
 
 _oldGroup setVariable["subGroup", _group];
+_oldGroup setVariable["groupLeader", leader _oldGroup];
 
 _newUnits joinSilent _group;
 private _newLeader = leader _group;
@@ -131,6 +132,9 @@ if (_rejoinCondition isEqualType {}) then {
         if ([_group, _newUnits, _args] call _rejoinCondition) then {
              _units joinSilent _oldGroup;
              deleteGroup _group;
+             if (_oldGroup getVariable["groupLeader", objNull] isNotEqualTo objNull && (_oldGroup getVariable "groupLeader") call EFUNC(FW,isAlive)) then {
+                _oldGroup selectLeader (_oldGroup getVariable "groupLeader");
+             };
              _oldGroup setVariable["subGroup", objNull];
         };
     }, 3, [

--- a/modules/headless_ai/functions/create/fn_finishGroupSpawn.sqf
+++ b/modules/headless_ai/functions/create/fn_finishGroupSpawn.sqf
@@ -64,7 +64,7 @@ if (
             (({ alive _x } count units _group) + _subGroupCount) <= _retreatCount;
         }, {
             params ["_group", "_retreatPos", "_retreatCount"];
-            [_group, _retreatPos, 50, "RETREAT"] call FUNC(taskAssault);
+            [_group, "RETREAT", _retreatPos, 50] call FUNC(taskAssign);
         }, [_group, _retreatPos, _retreatCount]] call CBA_fnc_waitUntilAndExecute;
     };
 

--- a/modules/headless_ai/functions/task/fn_taskAssault.sqf
+++ b/modules/headless_ai/functions/task/fn_taskAssault.sqf
@@ -36,6 +36,10 @@ SETVAR(_group,Task,"ASSAULT");
 
 [_group, _attackPos, _radius, "ASSAULT"] call FUNC(combatBound);
 
-[{GETVAR(_group,BoundPFH,objNull) isEqualTo objNull}, {
+[{
+    params ["_group", "_nextTask", "_attackPos"];
+    GETVAR(_group,BoundPFH,objNull) isEqualTo objNull;
+}, {
+    params ["_group", "_nextTask", "_attackPos"];
     [_group, _nextTask, _attackPos] call FUNC(taskAssign);
-}, [_group]]
+}, [_group, _nextTask, _attackPos]] call CBA_fnc_waitUntilAndExecute;

--- a/modules/headless_ai/functions/task/fn_taskAttack.sqf
+++ b/modules/headless_ai/functions/task/fn_taskAttack.sqf
@@ -14,7 +14,7 @@ params [
 SETVAR(_group,Task,"ATTACK");
 [_group] call FUNC(taskRelease);
 
-LOG_1("taskAssault started _this: %1",_this);
+LOG_1("taskAttack started _this: %1",_this);
 _group = _group call CBA_fnc_getGroup;
 if !(local _group) exitWith {}; // Don't create waypoints on each machine
 

--- a/modules/headless_ai/functions/task/fn_taskRetreat.sqf
+++ b/modules/headless_ai/functions/task/fn_taskRetreat.sqf
@@ -36,6 +36,10 @@ SETVAR(_group,Task,"RETREAT");
 
 [_group, _retreatPos, _radius, "RETREAT"] call FUNC(combatBound);
 
-[{GETVAR(_group,BoundPFH,objNull) isEqualTo objNull}, {
+[{
+    params ["_group", "_nextTask", "_retreatPos"];
+    GETVAR(_group,BoundPFH,objNull) isEqualTo objNull;
+}, {
+    params ["_group", "_nextTask", "_retreatPos"];
     [_group, _nextTask, _retreatPos] call FUNC(taskAssign);
-}, [_group]]
+}, [_group, _nextTask, _retreatPos]] call CBA_fnc_waitUntilAndExecute;

--- a/modules/headless_ai/functions/task/fn_taskRetreat.sqf
+++ b/modules/headless_ai/functions/task/fn_taskRetreat.sqf
@@ -2,7 +2,7 @@
 
 params [
     "_group",
-    "_attackPos",
+    "_retreatPos",
     ["_radius",100,[0]],
     ["_wait",3,[0]],
     ["_behaviour", "UNCHANGED", [""]],
@@ -10,32 +10,32 @@ params [
     ["_speed", "UNCHANGED", [""]],
     ["_formation", "NO CHANGE", [""]],
     ["_Type","MOVE",[""]],
-    ["_oncomplete",QUOTE(this call FUNC(taskSearchNearby)),[""]],
-    ["_nextTask","PATROL",[""]],
+    ["_oncomplete",QUOTE(this call FUNC(taskGarrison)),[""]],
+	["_nextTask","GARRISON",[""]],
     ["_compRadius",50,[0]],
     ["_wpcount",10,[0]]
 ];
 
 if (_radius < 30) then {
-    ERROR_1("taskAssault _group: %1 radius too small! Setting to default 30m",_group);
+    ERROR_1("taskRetreat _group: %1 radius too small! Setting to default 30m",_group);
     _radius = 30;
 };
 
-LOG_1("taskAssault started _this: %1",_this);
+LOG_1("taskRetreat started _this: %1",_this);
 _group = _group call CBA_fnc_getGroup;
 if !(local _group) exitWith {}; // Don't create waypoints on each machine
 
 //private _timeout = [(_wait*0.5), _wait, (_wait*1.5)];
-_attackPos = _attackPos call CBA_fnc_getPos;
+_retreatPos = _retreatPos call CBA_fnc_getPos;
 
 // Clear existing waypoints first
 [_group] call CBA_fnc_clearWaypoints;
 
-SETVAR(_group,Task,"ASSAULT");
+SETVAR(_group,Task,"RETREAT");
 [_group] call FUNC(taskRelease);
 
-[_group, _attackPos, _radius, "ASSAULT"] call FUNC(combatBound);
+[_group, _retreatPos, _radius, "RETREAT"] call FUNC(combatBound);
 
 [{GETVAR(_group,BoundPFH,objNull) isEqualTo objNull}, {
-    [_group, _nextTask, _attackPos] call FUNC(taskAssign);
+    [_group, _nextTask, _retreatPos] call FUNC(taskAssign);
 }, [_group]]


### PR DESCRIPTION
Think this addresses what you mentioned on discord, making the retreat stuff reusable in proper commander AI

**When merged this pull request will:**
- CombatAssault renamed to CombatBound
- Renamed assaultEngageDistance to engageDistance, consistent with use in other tasks
- Retreat is now its own task for future use in commander AI, pretty much the same as the assault task
- nextTask param in the assault & retreat tasks with sensible defaults. The CombatBound PFH no longer assigns the next task, it simply removes itself to indicate the bounding has ended, so scheduling next tasks is the tasks functions' responsibility
- fixed an edge case where if a subgroup was created which contained the original group's leader, the leader would not retain control over the original group upon rejoining
