### PR TITLE
fix AI quitting assault tasks early in some circumstances

### DIFF
--- a/modules/headless_ai/functions/Combat/fn_CombatBound.sqf
+++ b/modules/headless_ai/functions/Combat/fn_CombatBound.sqf
@@ -71,14 +71,13 @@ private _boundTaskPFH = [{
             (GETVAR(_group,Task,"PATROL")) isNotEqualTo "ATTACK" && 
             (GETVAR(_group,Task,"PATROL")) isNotEqualTo "RETREAT" 
         ) ||
-        {(GETVAR(_group,ExitBound,false))} ||
         {(getPosATL _leader distance2D _targetPos) <= _compRadius} ||
         {count _units <= 3} ||
         {_mode != "RETREAT" && _leader distance2D _nearestEnemy <= 15}
     ) exitWith {
         [_idPFH] call CBA_fnc_removePerFrameHandler;
         TRACE_1("Group exited Bound PFH",_group);
-        SETVAR(_group,ExitBound,false);
+        SETVAR(_group,ExitingBound,true);
         SETVAR(_group,BoundPFH,objNull);
         _group setCombatMode "YELLOW";
         _group setBehaviour "AWARE";
@@ -98,6 +97,7 @@ private _boundTaskPFH = [{
         if (GETVAR(_group,BoundPFH,objNull) isNotEqualTo objNull) then {
             [GETVAR(_group,BoundPFH,objNull)] call CBA_fnc_removePerFrameHandler;
         };
+        SETVAR(_group,ExitingBound,false);
         SETVAR(_group,BoundPFH,_idPFH);
         units _group apply {
             private _unit = _x;

--- a/modules/headless_ai/functions/task/fn_taskAssault.sqf
+++ b/modules/headless_ai/functions/task/fn_taskAssault.sqf
@@ -38,8 +38,9 @@ SETVAR(_group,Task,"ASSAULT");
 
 [{
     params ["_group", "_nextTask", "_attackPos"];
-    GETVAR(_group,BoundPFH,objNull) isEqualTo objNull;
+    GETVAR(_group,ExitingBound,false);
 }, {
     params ["_group", "_nextTask", "_attackPos"];
+    SETVAR(_group,ExitingBound,false);
     [_group, _nextTask, _attackPos] call FUNC(taskAssign);
 }, [_group, _nextTask, _attackPos]] call CBA_fnc_waitUntilAndExecute;

--- a/modules/headless_ai/functions/task/fn_taskRetreat.sqf
+++ b/modules/headless_ai/functions/task/fn_taskRetreat.sqf
@@ -38,8 +38,9 @@ SETVAR(_group,Task,"RETREAT");
 
 [{
     params ["_group", "_nextTask", "_retreatPos"];
-    GETVAR(_group,BoundPFH,objNull) isEqualTo objNull;
+    GETVAR(_group,ExitingBound,false);
 }, {
     params ["_group", "_nextTask", "_retreatPos"];
+    SETVAR(_group,ExitingBound,false);
     [_group, _nextTask, _retreatPos] call FUNC(taskAssign);
 }, [_group, _nextTask, _retreatPos]] call CBA_fnc_waitUntilAndExecute;


### PR DESCRIPTION
**When merged this pull request will:**
- Minor fix to an issue I introduced in the previous PR. AI were sometimes quitting assault tasks immediately (their next task was assigned before the PFH ran), this now leans on a previously unused group var instead of the PFH being present to 'complete' the bounding part of the task
