### PR TITLE
use combatLand for aerial dropoff tasks

### DIFF
--- a/modules/headless_ai/functions/Combat/fn_CombatDropOff.sqf
+++ b/modules/headless_ai/functions/Combat/fn_CombatDropOff.sqf
@@ -7,12 +7,17 @@ params [
 ];
 TRACE_1("combatDropOff started",_this);
 
-private _arrayTest = ["AUTOCOMBAT", "COVER", "SUPPRESSION", "AUTOTARGET", "TARGET"];
-_group enableAttack false;
 private _leader = leader _group;
 private _units = units _group;
 private _veh = vehicle _leader;
 private _driver = driver _veh;
+
+if (_veh isKindOf "Helicopter") exitWith {
+    [_group, _dropOffPos] call FUNC(combatLand);
+};
+
+private _arrayTest = ["AUTOCOMBAT", "COVER", "SUPPRESSION", "AUTOTARGET", "TARGET"];
+_group enableAttack false;
 [_leader, _driver] apply {
     private _unit = _x;
     _arrayTest apply {


### PR DESCRIPTION
**When merged this pull request will:**
- Use the CombatLand function when a heli is given a dropoff task
- Copied the code from CombatDropoff to unload groups when a helicopter is landed, may be worth moving this to a shared CombatUnload function in the future
- Setting an rtbPos param will have the heli return to the specified position and land again after performing their dropoff task

To see this change in action, follow the helos from the north of the map: http://aar.globalconflicts.net/?file=2024_09_28__15_15_CO34AxetoFallv1.json&frame=831&zoom=4&x=-68.27083587646484&y=130.78122559249204